### PR TITLE
Permissions speed #213

### DIFF
--- a/app/Http/Controllers/FormGroupController.php
+++ b/app/Http/Controllers/FormGroupController.php
@@ -83,7 +83,7 @@ class FormGroupController extends Controller {
                 //foreach of the user's project groups, see if one belongs to the current project
                 foreach($currGroups as $prev) {
                     $grp = FormGroup::where('id', '=', $prev->form_group_id)->first();
-                    if($grp->fid == $group->fid) {
+                    if($grp !== null && $grp->fid == $group->fid) {
                         $idOld = $grp->id;
                         $newUser = false;
                         break;

--- a/app/Http/Controllers/ProjectGroupController.php
+++ b/app/Http/Controllers/ProjectGroupController.php
@@ -269,11 +269,8 @@ class ProjectGroupController extends Controller {
         $instance->save();
 		
         $users = $instance->users()->get();
-		
-		$group = $instance;
-        $project = ProjectController::getProject($group->pid);
         foreach($users as $user) {
-            $this->emailUserProject("changed", $user->id, $group, $project);
+            $this->emailUserProject("changed", $user->id, $instance->id);
         }
     }
 

--- a/app/Http/Controllers/ProjectGroupController.php
+++ b/app/Http/Controllers/ProjectGroupController.php
@@ -91,23 +91,23 @@ class ProjectGroupController extends Controller {
                         $defGroup = FormGroup::where('name', '=', $form->name . ' Default Group')->get()->first();
                         $FGC = new FormGroupController();
                         $request->formGroup = $defGroup->id;
-                        $request->userId = $uid;
+                        $request->userIDs = array($uid);
                         $FGC->addUser($request);
                     }
 
-                    $this->emailUserProject("added", $uid, $group->id);
+                    //$this->emailUserProject("added", $uid, $group->id);
                 } else {
-                    $this->emailUserProject("changed", $uid, $group->id);
+                    //$this->emailUserProject("changed", $uid, $group->id);
                 }
-
-                //After all this, lets make sure they get the custom project added
-                $user = User::where("id","=",$uid)->first();
-                $user->addCustomProject($pid);
             }
+			
+			// add the users to the custom project
+			$project = Project::where('pid', '=', $pid)->first();
+			$project->batchAddUsersAsCustom($request->users);
 
             $group->users()->attach($request->users);
         }
-
+		
         return redirect('projects/'.$pid.'/manage/projectgroups')->with('k3_global_success', 'project_group_created');
     }
 
@@ -124,18 +124,16 @@ class ProjectGroupController extends Controller {
 
         $forms = Form::where('pid', '=', $instance->pid)->get();
         foreach($forms as $form) {
-          $formGroups = FormGroup::where('fid','=',$form->fid)->get();
-          foreach($formGroups as $fg) {
-            DB::table('form_group_user')->where('user_id', $request->userId)->where('form_group_id', $fg->id)->delete();
-          }
+			$fg_ids = FormGroup::where('fid','=',$form->fid)->pluck('id');
+			DB::table('form_group_user')->where('user_id', $request->userId)->whereIn('form_group_id', $fg_ids)->delete();
         }
 
         $user = User::where("id",(int)$request->userId)->first();
         $user->removeCustomProject($instance->pid);
-
+		
+		
         $instance->users()->detach($request->userId);
-
-        $this->emailUserProject("removed",$request->userId,$instance->id);
+        //$this->emailUserProject("removed",$request->userId,$instance->id);
     }
 
     /**
@@ -144,59 +142,75 @@ class ProjectGroupController extends Controller {
      * @param  Request $request
      */
     public function addUsers(Request $request) {
-      $instance = ProjectGroup::where('id', '=', $request->projectGroup)->first();
+		$instance = ProjectGroup::where('id', '=', $request->projectGroup)->first();
 
-      foreach ($request->userIDs as $userID) {
-        //get any groups the user belongs to
-        $currGroups = DB::table('project_group_user')->where('user_id', $userID)->get();
-        $newUser = true;
-        $group = null;
-        $idOld = 0;
-
-        //foreach of the user's project groups, see if one belongs to the current project
-        foreach($currGroups as $prev) {
-          $group = ProjectGroup::where('id', '=', $prev->project_group_id)->first();
-          if($group->pid == $instance->pid) {
-            $newUser = false;
-            $idOld = $group->id;
-            break;
-          }
-        }
-
-        if($newUser) {
-          $proj = ProjectController::getProject($instance->pid);
-
-          if($instance->name == $proj->name.' Admin Group') {
-            $tag = ' Admin Group';
-          } else {
-            $tag = ' Default Group';
-          }
-
-          //add to all forms
-          $forms = Form::where('pid', '=', $instance->pid)->get();
-          foreach($forms as $form) {
-            $defGroup = FormGroup::where('name', '=', $form->name . $tag)->where('fid','=',$form->fid)->get()->first();
-            $FGC = new FormGroupController();
-            $request->formGroup = $defGroup->id;
-            $request->userId = $userID;
-            $request->dontLookBack = true;
-            $FGC->addUser($request);
-          }
-
-          $this->emailUserProject("added", $userID, $instance->id);
+		$new_users = array();
+		foreach ($request->userIDs as $userID) {
+			//get any groups the user belongs to
+			$currGroups = DB::table('project_group_user')->where('user_id', $userID)->get();
+			$currGroups_ids = array();
+			foreach($currGroups as $group) {
+				array_push($currGroups_ids, $group->project_group_id);
+			}
+		
+			$newUser = true;
+			$group = null;
+			$idOld = 0;
+		
+			// for the user's project groups, see if one belongs to the current project
+			$groups = ProjectGroup::whereIn('id', $currGroups_ids)->get();
+			
+			foreach($groups as $group) {
+				if($group == null){Log::info("Null group"); continue;}
+				if ($group->pid == $instance->pid) {
+					$newUser = false;
+					$idOld = $group->id;
+					break;
+				}
+			}
+			
+			if($newUser) {
+				array_push($new_users, $userID);
+			} else {
+				//remove from old group
+				DB::table('project_group_user')->where('user_id', $userID)->where('project_group_id', $idOld)->delete();
+				//$this->emailUserProject("changed", $userID, $instance->id);
+				echo $idOld;
+			}
+	
+			$instance->users()->attach($userID);
+		}
+		
+	    $proj = ProjectController::getProject($instance->pid);
+		// add the users to the custom project
+		$proj->batchAddUsersAsCustom($request->userIDs);
+		
+		if($instance->name == $proj->name.' Admin Group') {
+			$tag = ' Admin Group';
         } else {
-          //remove from old group
-          DB::table('project_group_user')->where('user_id', $userID)->where('project_group_id', $idOld)->delete();
-          $this->emailUserProject("changed", $userID, $instance->id);
-          echo $idOld;
+			$tag = ' Default Group';
         }
-
-        //After all this, lets make sure they get the custom project added
-        $user = User::where("id",$userID)->first();
-        $user->addCustomProject($instance->pid);
-
-        $instance->users()->attach($userID);
-      }
+		$forms = Form::where('pid', '=', $instance->pid)->get();
+		
+		$names = array(); $fids = array();
+		foreach ($forms as $form) {
+			array_push($names, $form->name . $tag);
+			$fids[$form->fid] = true;
+		}
+		
+		$possible_formgroups = FormGroup::whereIn('name', $names)->get();
+		$wanted_form_group_ids = array();
+		
+		foreach ($possible_formgroups as $form_group) {
+			if (isset($fids[$form_group->fid])) { // this filters out form groups with same name but different fid
+				$FGC = new FormGroupController();
+				$request->formGroup = $form_group;
+				$request->_internal = true;
+				$request->dontLookBack = true;
+				$request->userIDs = $new_users;
+				$FGC->addUser($request);
+			}
+		}
     }
 
     /**
@@ -221,7 +235,7 @@ class ProjectGroupController extends Controller {
             //Remove their custom project connection
             $user->removeCustomProject($instance->pid);
 
-            $this->emailUserProject("removed",$user->id,$instance->id);
+            //$this->emailUserProject("removed", $user->id, $instance->id);
         }
 
         $instance->delete();
@@ -253,10 +267,13 @@ class ProjectGroupController extends Controller {
             $instance->delete = 0;
 
         $instance->save();
-
+		
         $users = $instance->users()->get();
+		
+		$group = $instance;
+        $project = ProjectController::getProject($group->pid);
         foreach($users as $user) {
-            $this->emailUserProject("changed",$user->id,$instance->id);
+            //$this->emailUserProject("changed", $user->id, $group, $project);
         }
     }
 
@@ -320,13 +337,13 @@ class ProjectGroupController extends Controller {
      *
      * @param  string $type - Method to execute
      * @param  int $uid - User ID
-     * @param  int $pgid - Project Group ID
+     * @param  ProjectGroup 
+	 * @param  Project
      */
-    private function emailUserProject($type, $uid, $pgid) {
-        $userMail = DB::table('users')->where('id', $uid)->value('email');
-        $name = DB::table('users')->where('id', $uid)->value('first_name');
-        $group = ProjectGroup::where('id', '=', $pgid)->first();
-        $project = ProjectController::getProject($group->pid);
+    private function emailUserProject($type, $uid, $group, $project) {
+		$user_data = DB::table('users')->where('id', $uid)->first();
+        $userMail = $user_data->value('email');
+        $name = $user_data->value('first_name');
 
         if($type=="added") {
             $email = 'emails.project.added';

--- a/app/User.php
+++ b/app/User.php
@@ -606,7 +606,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
                 $newSeq = $currSeqMax + 1;
             else
                 $newSeq = 0;
-
+			
             DB::table('project_custom')->insert(
                 ['uid' => $this->id, 'pid' => $pid, 'sequence' => $newSeq,
                     "created_at" =>  Carbon::now(),

--- a/public/assets/javascripts/formGroups/index.js
+++ b/public/assets/javascripts/formGroups/index.js
@@ -3,7 +3,6 @@ Kora.FormGroups = Kora.FormGroups || {};
 
 Kora.FormGroups.Index = function() {
   var self = Kora.FormGroups.Index;
-  self.last_cooldown = Date.now();
 
 
   /**
@@ -457,10 +456,6 @@ Kora.FormGroups.Index = function() {
       var data = $(this).data('value');
       var removeUser = function(e) {
         e.preventDefault();
-		if (Date.now() - self.last_cooldown < 150) {
-			return;
-		}
-		self.last_cooldown = Date.now();
         self.removeUser(data[0], data[1], data[2]);
       };
 

--- a/public/assets/javascripts/formGroups/index.js
+++ b/public/assets/javascripts/formGroups/index.js
@@ -3,6 +3,7 @@ Kora.FormGroups = Kora.FormGroups || {};
 
 Kora.FormGroups.Index = function() {
   var self = Kora.FormGroups.Index;
+  self.last_cooldown = Date.now();
 
 
   /**
@@ -456,6 +457,10 @@ Kora.FormGroups.Index = function() {
       var data = $(this).data('value');
       var removeUser = function(e) {
         e.preventDefault();
+		if (Date.now() - self.last_cooldown < 150) {
+			return;
+		}
+		self.last_cooldown = Date.now();
         self.removeUser(data[0], data[1], data[2]);
       };
 


### PR DESCRIPTION
Relevant issue: #213 

Added a new function to ProjectGroupController called batchAddUsersAsCustom which accepts an array of users. This function adds a project to multiple users' custom lists with 1 query and 1 insertion. This replaces iterative use of User::AddCustomProject in ProjectGroupController::create, ProjectGroupController::addUsers, and ProjectGroup::makeAdminGroup.

For ProjectGroupController::addUsers:
< Batched iterative ProjectGroup queries into a single query such that there is now 1 query to fetch the ProjectGroups per user instead of a query for every project group for every user.
< Batched 'new user' operations. Instead of making a call to FormGroupController:addUsers for every new user, a single call is now made with every new user in it. Moved code that fetches the same Forms every time to outside of a loop. Batched fetching FormGroups for new users so that there is only 1 query for all the new users. Also added an optimization that sends the fetched FormGroup to FormGroupController::addUsers instead of doing an unnecessary query by sending the id and fetching it again.
< Fixed a bug here where a new FormGroupController was being made for every user when we only need one for every FormGroup.

For FormGroupController::addUsers:
< Batched fetching FormGroups such that 1 query is performed to fetch the FormGroups per user, instead of a query for every form group for every user.
< Batched insertions into 'project_group_id'.

Reduced number of deletions performed by ProjectGroupController::removeUser by deleting multiple entries from 'form_group_user' at once (batching).

Fixed small bug in ProjectGroupController::addUser where a call to FormGroupController::addUser had incorrect arguments, causing it to fail.