### PR TITLE
fixed undefined var causing error on single project page load when 0 forms in project

### DIFF
--- a/resources/views/projects/show.blade.php
+++ b/resources/views/projects/show.blade.php
@@ -36,6 +36,7 @@
   @if($notification)
     @include('partials.projects.notification')
   @endif
+  @php $pref = 'single_proj_page_tab_selection' @endphp
   @if (count($forms) > 0)
   <section class="filters center">
       <div class="underline-middle search search-js">
@@ -44,7 +45,6 @@
         <i class="icon icon-cancel icon-cancel-js"></i>
       </div>
       <div class="sort-options sort-options-js">
-          @php $pref = 'single_proj_page_tab_selection' @endphp
           <!-- <a href="modified" class="option underline-middle">Recently Modified</a> -->
           <a href="#custom" class="option underline-middle underline-middle-hover {{ \App\Http\Controllers\Auth\UserController::returnUserPrefs($pref) == "2" ? 'active' : ''}}">Custom</a>
           <a href="#active" class="option underline-middle underline-middle-hover {{ \App\Http\Controllers\Auth\UserController::returnUserPrefs($pref) == "3" ? 'active' : ''}}">Alphabetical</a>


### PR DESCRIPTION
No styling changes, just a simple bug fix.

Relevant issue: #322 