### PR TITLE
Document field error #368

### DIFF
--- a/app/DocumentsField.php
+++ b/app/DocumentsField.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\FieldController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 
 class DocumentsField extends FileTypeField {
@@ -87,10 +88,17 @@ class DocumentsField extends FileTypeField {
      * @return Redirect
      */
     public function updateOptions($field, Request $request) {
-        $filetype = $request->filetype[0];
-        for($i=1;$i<sizeof($request->filetype);$i++) {
-            $filetype .= '[!]'.$request->filetype[$i];
-        }
+		Log::info("updateOptions in DocumentsField");
+		Log::info($request);
+		
+		$has_filetype = isset($request->filetype);
+		
+		if ($has_filetype) {
+			$filetype = $request->filetype[0];
+			for($i=1;$i<sizeof($request->filetype);$i++) {
+				$filetype .= '[!]'.$request->filetype[$i];
+			}
+		}
 
         if($request->filesize=='')
             $request->filesize = 0;
@@ -102,7 +110,7 @@ class DocumentsField extends FileTypeField {
         $field->updateSearchable($request);
         $field->updateOptions('FieldSize', $request->filesize);
         $field->updateOptions('MaxFiles', $request->maxfiles);
-        $field->updateOptions('FileTypes', $filetype);
+        $field->updateOptions('FileTypes', $has_filetype ? $filetype : "");
 
         return redirect('projects/' . $field->pid . '/forms/' . $field->fid . '/fields/' . $field->flid . '/options')
             ->with('k3_global_success', 'field_options_updated');
@@ -117,6 +125,8 @@ class DocumentsField extends FileTypeField {
      * @param  Request $request
      */
     public function createNewRecordField($field, $record, $value, $request) {
+		Log::info("createNewRecordField in DocumentsField");
+		
         if(glob(storage_path('app/tmpFiles/' . $value . '/*.*')) != false) {
             $this->flid = $field->flid;
             $this->rid = $record->rid;

--- a/app/DocumentsField.php
+++ b/app/DocumentsField.php
@@ -4,7 +4,6 @@ use App\Http\Controllers\FieldController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 
 class DocumentsField extends FileTypeField {
@@ -88,9 +87,6 @@ class DocumentsField extends FileTypeField {
      * @return Redirect
      */
     public function updateOptions($field, Request $request) {
-		Log::info("updateOptions in DocumentsField");
-		Log::info($request);
-		
 		$has_filetype = isset($request->filetype);
 		
 		if ($has_filetype) {
@@ -125,8 +121,6 @@ class DocumentsField extends FileTypeField {
      * @param  Request $request
      */
     public function createNewRecordField($field, $record, $value, $request) {
-		Log::info("createNewRecordField in DocumentsField");
-		
         if(glob(storage_path('app/tmpFiles/' . $value . '/*.*')) != false) {
             $this->flid = $field->flid;
             $this->rid = $record->rid;


### PR DESCRIPTION
Fixes page erroring out on field create when creating a new Document field and clicking on the Advanced options but then not specifying a filetype.

Relevant issue: #368 