### PR TITLE
Form Records & Search Page UX #376

### DIFF
--- a/app/Http/Controllers/RecordController.php
+++ b/app/Http/Controllers/RecordController.php
@@ -13,7 +13,6 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 use RecursiveIteratorIterator;
@@ -473,8 +472,6 @@ class RecordController extends Controller {
      * @return Redirect
      */
     public function destroy($pid, $fid, $rid, $mass = false) {
-		//Log::info("RecordController@destroy entered");
-		
         if(!self::validProjFormRecord($pid, $fid, $rid))
             return redirect('projects')->with('k3_global_error', 'record_invalid');
 
@@ -503,11 +500,8 @@ class RecordController extends Controller {
       $form = FormController::getForm($fid);
       $rid = $request->rid;
       $rid = explode(',', $rid);
-	  
-	  //Log::info("RecordController@deleteMultipleRecords entered");
 
       if(!\Auth::user()->isFormAdmin($form)) {
-		//Log::info("RecordController@deleteMultipleRecords Not a form admin");
         return redirect('projects')->with('k3_global_error', 'not_form_admin');
       } else {
         foreach($rid as $rid) {

--- a/app/Http/Controllers/RecordController.php
+++ b/app/Http/Controllers/RecordController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Redirect;
 use Illuminate\View\View;
 use RecursiveIteratorIterator;
@@ -472,6 +473,8 @@ class RecordController extends Controller {
      * @return Redirect
      */
     public function destroy($pid, $fid, $rid, $mass = false) {
+		//Log::info("RecordController@destroy entered");
+		
         if(!self::validProjFormRecord($pid, $fid, $rid))
             return redirect('projects')->with('k3_global_error', 'record_invalid');
 
@@ -485,7 +488,7 @@ class RecordController extends Controller {
 
         $record->delete();
 
-        return redirect()->action('FormController@show', ['pid' => $pid, 'fid' => $fid])->with('k3_global_success', 'record_deleted');
+		return redirect('projects/' . $pid . '/forms/' . $fid . '/records')->with('k3_global_success', 'record_deleted');
     }
 
     /**
@@ -500,8 +503,11 @@ class RecordController extends Controller {
       $form = FormController::getForm($fid);
       $rid = $request->rid;
       $rid = explode(',', $rid);
+	  
+	  //Log::info("RecordController@deleteMultipleRecords entered");
 
       if(!\Auth::user()->isFormAdmin($form)) {
+		//Log::info("RecordController@deleteMultipleRecords Not a form admin");
         return redirect('projects')->with('k3_global_error', 'not_form_admin');
       } else {
         foreach($rid as $rid) {

--- a/public/assets/javascripts/records/toolbar.js
+++ b/public/assets/javascripts/records/toolbar.js
@@ -158,9 +158,12 @@ Kora.Records.Toolbar = function() {
         data: values,
         success: function(data) {
           $form.submit();
-          //console.log('success!');
+          
+		  resetSelectAndHideToolbar();
         },
         error: function(error) {
+		  resetSelectAndHideToolbar();
+			
           if (error.status == 200) {
             //location.reload();
             console.log(error);
@@ -179,9 +182,27 @@ Kora.Records.Toolbar = function() {
       });
     });
   }
+  
+  function resetSelectAndHideToolbar() {
+	  $('.checked').trigger('click'); // unselect the checkboxes
+	  
+	  window.localStorage.removeItem('selectedRecords');
+	  selected = [];
+	  count = selected.length;
+	  
+	  $('.toolbar').addClass('hidden'); // hide the toolbar
+	  $('.record-index').removeClass('with-bottom');
+	}
+	
+  function initializeSingleRecordDelete() {
+	$(".single-record-delete-js").click(function() {
+	  resetSelectAndHideToolbar();
+	});
+  }
 
   initializeDeleteRecord();
   initializeExportRecords();
+  initializeSingleRecordDelete();
   recordSelect();
   batchAssign();
   deleteMultiple();

--- a/public/assets/javascripts/records/toolbar.js
+++ b/public/assets/javascripts/records/toolbar.js
@@ -165,11 +165,8 @@ Kora.Records.Toolbar = function() {
 		  resetSelectAndHideToolbar();
 			
           if (error.status == 200) {
-            //location.reload();
-            console.log(error);
-            console.log(error.status);
+            
           } else {
-            console.log(error);
             var responseJson = error.responseJSON;
             $.each(responseJson, function() {
               console.log('error: ' + this[0]);

--- a/resources/views/partials/records/modals/deleteRecordModal.blade.php
+++ b/resources/views/partials/records/modals/deleteRecordModal.blade.php
@@ -24,7 +24,7 @@
                 </div>
 
                 <div class="form-group">
-                    {!! Form::submit('Delete Record',['class' => 'btn warning']) !!}
+                    {!! Form::submit('Delete Record',['class' => 'btn warning single-record-delete-js']) !!}
                 </div>
             {!! Form::close() !!}
         </div>


### PR DESCRIPTION
Changes on the Form Record & Search Page:
Single record delete and batch record delete actions now both keep the user on the Form Record & Search Page.
Single record delete and batch record delete actions now both clear the selections and hide the selections toolbar.

fixes #376 