### PR TITLE
fix for 500 page for production mode

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -39,8 +39,7 @@ class Handler extends ExceptionHandler {
 	public function render($request, Exception $exception)
 	{		
 		if (config('app.env') === 'production' && $exception instanceof \ErrorException) {
-			$install_admin = User::where('id','=',1)->first();
-			return response()->view('errors.500', ['install_admin_email' => $install_admin->email], 500);
+			return response()->view('errors.500', [], 500);
 		}
 		
 		return parent::render($request, $exception);

--- a/resources/views/errors/500.blade.php
+++ b/resources/views/errors/500.blade.php
@@ -7,7 +7,7 @@
         <div class="form-container center">
 			<div class="subheader mt-m">Whoops, something went wrong.</div>
 			<div class="main-info mt-xxxl">Feel free to contact the Installation Admin</div>
-			<a href="mailto:{{$install_admin_email}}" class="link">{{$install_admin_email}}</a>
+			<a href="mailto:{{DB::table('users')->where('id', '=', 1)->first()->email}}" class="link">{{DB::table('users')->where('id', '=', 1)->first()->email}}</a>
 			<div class="main-info">about this problem, or ...</div>
 			
 			<button id="back-button" class="footer-spacing btn mt-xxxl" type="submit">Go Back</button>


### PR DESCRIPTION
Brings back the 500 page view and stops Laravel log spam on production mode installs.
fixes #459 