### PR TITLE
fixed name disappearing bug on user management page when changing sorts

### DIFF
--- a/public/assets/javascripts/admin/users.js
+++ b/public/assets/javascripts/admin/users.js
@@ -147,6 +147,8 @@ Kora.Admin.Users = function() {
 
     // Display corresponding content
     content.addClass('active');
+	
+	$(window).resize(); // fixes name disappearing bug
   }
 
   /**


### PR DESCRIPTION
Fixes names disappearing when changing sort option on User Management by firing off a resize event.
fixes #420 